### PR TITLE
Add support for UTF-8 Enum values

### DIFF
--- a/avro_schema/frontend.lua
+++ b/avro_schema/frontend.lua
@@ -389,7 +389,7 @@ copy_schema = function(schema, ns, scope, open_rec, options)
                 local symbolmap = {}
                 for symbolno, symbol in ipairs(xsymbols) do
                     symbol = tostring(symbol)
-                    if not validname(symbol) then
+                    if not validname(symbol) and not options.utf8_enums then
                         copy_schema_error('Bad enum symbol name: %s', symbol)
                     end
                     if symbolmap[symbol] then


### PR DESCRIPTION
Call avro.create(schema, {utf8_enums=true}) to use this feature

In context of #42 