### PR TITLE
Fix validate float

### DIFF
--- a/avro_schema/frontend.lua
+++ b/avro_schema/frontend.lua
@@ -665,7 +665,24 @@ copy_data = function(schema, data, visited)
         end
         return data
     elseif schematype == 'double' or schematype == 'float' then
-        return 0 + tonumber(data)
+        local xtype = type(data)
+        if xtype == "number" then
+            return data
+        else
+            if xtype == "cdata" then
+                local xdata = tonumber(data)
+                if xdata == nil then
+                    -- `tonumber` returns `nil` in case of an error
+                    -- crutch: replace data with typeof(data) to produce more
+                    -- readable error message
+                    data = ffi.typeof(data)
+                    error()
+                else
+                    return xdata
+                end
+            end
+        end
+        error()
     elseif schematype == 'bytes' or schematype == 'string' then
         if type(data) ~= 'string' then
             error()

--- a/test/ddt_suite/validate.lua
+++ b/test/ddt_suite/validate.lua
@@ -169,8 +169,27 @@ t {
 
 t {
     schema = '"float"',
+    validate = ffi.new("char", 1),
+    validate_only = true
+}
+
+t {
+    schema = '"float"',
     validate = '"Hello!"',
     validate_error = 'Not a float: Hello!'
+}
+
+t {
+    schema = '"float"',
+    validate = '"0"',
+    validate_error = 'Not a float: 0'
+}
+
+
+t {
+    schema = '"float"',
+    validate = ffi.new("const char *", "some string"),
+    validate_error = 'Not a float: ctype<const char *>'
 }
 
 -- double
@@ -195,8 +214,26 @@ t {
 
 t {
     schema = '"double"',
+    validate = ffi.new("char", 1),
+    validate_only = true
+}
+
+t {
+    schema = '"double"',
     validate = '"Hello!"',
     validate_error = 'Not a double: Hello!'
+}
+
+t {
+    schema = '"double"',
+    validate = '"0"',
+    validate_error = 'Not a double: 0'
+}
+
+t {
+    schema = '"double"',
+    validate = ffi.new("const char *", "some string"),
+    validate_error = 'Not a double: ctype<const char *>'
 }
 
 -- string

--- a/test/run_ddt_tests.lua
+++ b/test/run_ddt_tests.lua
@@ -6,6 +6,7 @@ local debug          = require('debug')
 local json           = require('json')
 local fio            = require('fio')
 local schema         = require('avro_schema')
+local ffi            = require('ffi')
 local max            = math.max
 local base64_encode  = digest.base64_encode
 local format, gsub   = string.format, string.gsub
@@ -242,7 +243,7 @@ local stages = {
 
 -- test-id is <file-name>-<line>
 local test_name, test_env
-local test_env_ignore = {_G = true, t = true}
+local test_env_ignore = {_G = true, t = true, ffi = true}
 local function test_id(caller)
     local keys = {}
     for k in pairs(test_env) do
@@ -283,7 +284,7 @@ local function run_tests(dir)
         local result, extra = loadfile(path)
         if not result then error(extra) end
         local test = result
-        test_env = { t = t }
+        test_env = { t = t, ffi = ffi }
         test_env._G = test_env
         setfenv(test, test_env)
         test_name = gsub(gsub(path, '.*/', ''), '%.lua$', '')


### PR DESCRIPTION
Before this commit it was allowed to pass `"0"` to float or double
field, because it the validator were using `tonumber` function.

The behavior is changed due to the following reasons:
- This behavior is not added intentionally (It is from initial commit).
- A compiled schema cannot flatten a string even if it can be cast to
  float.
- Int or long types do not allow strings at all.

Closes #60