### PR TITLE
test: fix module reload test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,7 +133,7 @@ add_test(NAME buf_grow_test
          WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/test)
 
 set(TESTS ddt_tests api_tests/var api_tests/export
-    api_tests/evolution buf_grow_test)
+    api_tests/evolution api_tests/reload buf_grow_test)
 foreach(test IN LISTS TESTS)
 
     set_property(TEST ${test} PROPERTY ENVIRONMENT "LUA_PATH=${LUA_PATH}")

--- a/test/api_tests/reload.lua
+++ b/test/api_tests/reload.lua
@@ -5,10 +5,17 @@ test:plan(1)
 
 test:test('reload test', function(test)
     test:plan(1)
+
+    -- Require the module first time.
+    require('avro_schema')
+
+    -- Unload it.
     package.loaded['avro_schema'] = nil
     package.loaded['avro_schema.il'] = nil
-    local ok = pcall(require, 'avro_schema')
-    test:ok(ok, 'Successfully reloaded')
+
+    -- Require it again.
+    local ok, err = pcall(require, 'avro_schema')
+    test:ok(ok, 'Successfully reloaded', {err = err})
 end)
 
 os.exit(test:check() and 0 or 1)


### PR DESCRIPTION
This commit follows up bbcf5fc14e3fd1962351574d3f6c30e84bcf7c92 ('fix:
allow to reload module') and fixes the test by passing correct LUA_PATH.

Enhanced the test itself a bit: added first require (w/o it the case
will pass, but will not actually verify reloading), add an error to the
`ctest -VV` output if the test will fail, added comments.

Follows up #34.