### PR TITLE
Revert "Give variables the same names in ir and in lua"

### DIFF
--- a/avro_schema/backend.lua
+++ b/avro_schema/backend.lua
@@ -19,8 +19,6 @@ local random_bytes   = digest.base64_decode([[
 X1CntcveBDc4inHKyWfyXw5iCjg1f3TmeX88pZ2Galb9tXpTt1uBO0pZrkU5NW1/4Ki9g8fAwElq
 B3dRsBscsg==]])
 
--- The procedure gives ids to variables which then used to generate its names.
--- The general rule is to give the same number as it was in `ir` representation.
 local sched_variables_helper
 sched_variables_helper = function(block, n, varmap, reusequeue)
     for i = 1, #block do
@@ -33,7 +31,7 @@ sched_variables_helper = function(block, n, varmap, reusequeue)
                 var = n + 1
                 n = var
             end
-            varmap[o.ipv] = o.ipv
+            varmap[o.ipv] = var
         elseif o.op == opcode.ENDVAR then
             insert(reusequeue, varmap[o.ipv])
         end
@@ -598,43 +596,22 @@ emit_nested_block = function(ctx, block, cc, res)
     insert(queue, cc)
 end
 
--- The procedure emits local variables with names corresponding to their
--- register numbers in `ir` representation
-local function emit_locals(varmap, nservice_fields, res)
-    if nservice_fields then
-        -- Allocate variables for service_fields like this:
-        -- local sf1
-        -- local sf2 ...
-        for num = 1, nservice_fields do
-            insert(res, format('local sf%d', num))
-        end
-    end
-    local var_nums = {}
-    for _, num in pairs(varmap) do
-        table.insert(var_nums, num)
-    end
-    local pos = 0
-    -- generate batches like: local x1, x2, x3, x4
-    -- until it there are 4 or more variables still
-    while pos < #var_nums - 4 do
-        insert(res, format('local x%d, x%d, x%d, x%d',
-            var_nums[pos + 1],
-            var_nums[pos + 2],
-            var_nums[pos + 3],
-            var_nums[pos + 4]))
-        pos = pos + 4
-    end
-    -- emit variables by one if less then 4 left
-    while pos < #var_nums do
-        insert(res, format('local x%d',
-            var_nums[pos + 1]))
-        pos = pos + 1
-    end
-end
+local locals_tab = {
+    [0] = 'local x%d',
+    'local x%d, x%d',
+    'local x%d, x%d, x%d'
+}
 
 local function emit_func_body(il, func, nlocals_min, res)
-    local _, varmap = sched_func_variables(func)
-    emit_locals(varmap, nlocals_min, res)
+    local nlocals, varmap = sched_func_variables(func)
+    if nlocals_min and nlocals_min > nlocals then
+        nlocals = nlocals_min
+    end
+    for i = 1, nlocals, 4 do
+        insert(res, format(locals_tab[nlocals - i] or
+                           'local x%d, x%d, x%d, x%d',
+                           i, i+1, i+2, i+3))
+    end
     if il.enable_loop_peeling then
         peel_annotate(func, 0)
     end

--- a/avro_schema/init.lua
+++ b/avro_schema/init.lua
@@ -250,16 +250,16 @@ local function gen_fetch_service_fields(service_fields)
     local code = {}
     for i, field in ipairs(service_fields) do
         if field == 'boolean' then
-            insert(code, format('sf%d = r.t[%d] == 3', i, i))
+            insert(code, format('x%d = r.t[%d] == 3', i, i))
         elseif field == 'int' then
-            insert(code, format('sf%d = tonumber(r.v[%d].ival)', i, i))
+            insert(code, format('x%d = tonumber(r.v[%d].ival)', i, i))
         elseif field == 'long' then
-            insert(code, format('sf%d = r.v[%d].ival', i, i))
+            insert(code, format('x%d = r.v[%d].ival', i, i))
         elseif field == 'float' or field == 'double' then
-            insert(code, format('sf%d = r.v[%d].dval', i, i))
+            insert(code, format('x%d = r.v[%d].dval', i, i))
         elseif field == 'string' or field == 'bytes' then
             insert(code, format([[
-sf%d = ffi_string(r.b1-r.v[%d].xoff, r.v[%d].xlen)]], i, i, i))
+x%d = ffi_string(r.b1-r.v[%d].xoff, r.v[%d].xlen)]], i, i, i))
         else
             assert(false)
         end
@@ -345,7 +345,7 @@ r = rt_regs; v0 = 0; v1 = 0
 msgpack_data = decode_proc(r, data)
 r.b2 = ffi_cast("const uint8_t *", cpool) + #cpool]],
         conversion_complete = concat(u_complete, '\n'),
-        func_return = 'return v0' .. param_list(n, 'sf'),
+        func_return = 'return v0' .. param_list(n, 'x'),
         iter_prolog = 'if _ < 16 then goto continue end' -- artificially bump iter count
     })
 

--- a/test/ddt_suite/compile_large.lua
+++ b/test/ddt_suite/compile_large.lua
@@ -1,0 +1,561 @@
+local large = [[{
+    "type": "record",
+    "name": "type_1",
+    "fields": [
+        {
+            "name": "field_1",
+            "type": "long"
+        },
+        {
+            "name": "field_2",
+            "type": "long"
+        },
+        {
+            "name": "field_3",
+            "type": "string"
+        },
+        {
+            "name": "field_4",
+            "type": "string"
+        },
+        {
+            "name": "field_5",
+            "type": {
+                "type": "record",
+                "name": "type_2",
+                "fields": [
+                    {
+                        "name": "field_6",
+                        "type": "string"
+                    },
+                    {
+                        "name": "field_7",
+                        "type": "string"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "field_8",
+            "type": "string"
+        },
+        {
+            "name": "field_9",
+            "type": {
+                "type": "array",
+                "items": "type_1"
+            }
+        },
+        {
+            "name": "field_10",
+            "type": {
+                "type": "array",
+                "items": {
+                    "type": "record",
+                    "name": "type_3",
+                    "fields": [
+                        {
+                            "name": "field_11",
+                            "type": "string"
+                        },
+                        {
+                            "name": "field_12",
+                            "type": {
+                                "type": "record",
+                                "name": "type_4",
+                                "fields": [
+                                    {
+                                        "name": "field_13",
+                                        "type": "long"
+                                    },
+                                    {
+                                        "name": "field_14",
+                                        "type": {
+                                            "type": "record",
+                                            "name": "type_5",
+                                            "fields": [
+                                                {
+                                                    "name": "field_15",
+                                                    "type": "long"
+                                                },
+                                                {
+                                                    "name": "field_16",
+                                                    "type": "string"
+                                                },
+                                                {
+                                                    "name": "field_17",
+                                                    "type": "string"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "name": "field_18",
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "field_19",
+                            "type": {
+                                "type": "array",
+                                "items": {
+                                    "type": "record",
+                                    "name": "type_6",
+                                    "fields": [
+                                        {
+                                            "name": "field_20",
+                                            "type": {
+                                                "type": "string"
+                                            }
+                                        },
+                                        {
+                                            "name": "field_21",
+                                            "type": {
+                                                "type": "string"
+                                            }
+                                        },
+                                        {
+                                            "name": "field_22",
+                                            "type": "boolean"
+                                        },
+                                        {
+                                            "name": "field_23",
+                                            "type": "string"
+                                        },
+                                        {
+                                            "name": "field_24",
+                                            "type": {
+                                                "type": "record",
+                                                "name": "type_7",
+                                                "fields": [
+                                                    {
+                                                        "name": "field_25",
+                                                        "type": "long"
+                                                    },
+                                                    {
+                                                        "name": "field_26",
+                                                        "type": "string"
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        {
+                                            "name": "field_27",
+                                            "type": "type_2"
+                                        },
+                                        {
+                                            "name": "field_28",
+                                            "type": "string"
+                                        },
+                                        {
+                                            "name": "field_29",
+                                            "type": {
+                                                "type": "record",
+                                                "name": "type_8",
+                                                "fields": [
+                                                    {
+                                                        "name": "field_30",
+                                                        "type": "long"
+                                                    },
+                                                    {
+                                                        "name": "field_31",
+                                                        "type": "string"
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        {
+                                            "name": "field_32",
+                                            "type": {
+                                                "type": "record",
+                                                "name": "type_9",
+                                                "fields": [
+                                                    {
+                                                        "name": "field_33",
+                                                        "type": "long"
+                                                    },
+                                                    {
+                                                        "name": "field_34",
+                                                        "type": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    {
+                                                        "name": "field_35",
+                                                        "type": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    {
+                                                        "name": "field_36",
+                                                        "type": "string"
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                        {
+                            "name": "field_37",
+                            "type": "long"
+                        },
+                        {
+                            "name": "field_38",
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "field_39",
+                            "type": "long"
+                        },
+                        {
+                            "name": "field_40",
+                            "type": "long"
+                        },
+                        {
+                            "name": "field_41",
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "field_42",
+                            "type": "long"
+                        },
+                        {
+                            "name": "field_43",
+                            "type": "type_7"
+                        },
+                        {
+                            "name": "field_44",
+                            "type": "type_2"
+                        },
+                        {
+                            "name": "field_45",
+                            "type": {
+                                "type": "array",
+                                "items": {
+                                    "type": "record",
+                                    "name": "type_10",
+                                    "fields": [
+                                        {
+                                            "name": "field_46",
+                                            "type": "string"
+                                        },
+                                        {
+                                            "name": "field_47",
+                                            "type": "string"
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "name": "field_48",
+            "type": {
+                "type": "array",
+                "items": {
+                    "type": "record",
+                    "name": "type_11",
+                    "fields": [
+                        {
+                            "name": "field_49",
+                            "type": "long"
+                        },
+                        {
+                            "name": "field_50",
+                            "type": "string"
+                        },
+                        {
+                            "name": "field_51",
+                            "type": {
+                                "type": "string"
+                            }
+                        },
+                        {
+                            "name": "field_52",
+                            "type": "type_7"
+                        },
+                        {
+                            "name": "field_53",
+                            "type": {
+                                "type": "record",
+                                "name": "type_12",
+                                "fields": [
+                                    {
+                                        "name": "field_54",
+                                        "type": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    {
+                                        "name": "field_55",
+                                        "type": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    {
+                                        "name": "field_56",
+                                        "type": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    {
+                                        "name": "field_57",
+                                        "type": "boolean"
+                                    },
+                                    {
+                                        "name": "field_58",
+                                        "type": "string"
+                                    },
+                                    {
+                                        "name": "field_59",
+                                        "type": "type_2"
+                                    },
+                                    {
+                                        "name": "field_60",
+                                        "type": "string"
+                                    },
+                                    {
+                                        "name": "field_61",
+                                        "type": "type_8"
+                                    },
+                                    {
+                                        "name": "field_62",
+                                        "type": "type_7"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "name": "field_63",
+                            "type": {
+                                "type": "record",
+                                "name": "type_13",
+                                "fields": [
+                                    {
+                                        "name": "field_64",
+                                        "type": "long"
+                                    },
+                                    {
+                                        "name": "field_65",
+                                        "type": "long"
+                                    },
+                                    {
+                                        "name": "field_66",
+                                        "type": "long"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "name": "field_67",
+            "type": {
+                "type": "record",
+                "name": "type_14",
+                "fields": [
+                    {
+                        "name": "field_68",
+                        "type": "string"
+                    },
+                    {
+                        "name": "field_69",
+                        "type": "string"
+                    },
+                    {
+                        "name": "field_70",
+                        "type": "long"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "field_71",
+            "type": {
+                "type": "array",
+                "items": {
+                    "type": "record",
+                    "name": "type_15",
+                    "fields": [
+                        {
+                            "name": "field_72",
+                            "type": "string"
+                        },
+                        {
+                            "name": "field_73",
+                            "type": "string"
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "name": "field_74",
+            "type": {
+                "type": "record",
+                "name": "type_16",
+                "fields": [
+                    {
+                        "name": "field_75",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "field_76",
+                        "type": "string"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "field_77",
+            "type": {
+                "type": "array",
+                "items": {
+                    "type": "record",
+                    "name": "type_17",
+                    "fields": [
+                        {
+                            "name": "field_78",
+                            "type": {
+                                "type": "string"
+                            }
+                        },
+                        {
+                            "name": "field_79",
+                            "type": "type_4"
+                        },
+                        {
+                            "name": "field_80",
+                            "type": "type_4"
+                        },
+                        {
+                            "name": "field_81",
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "field_82",
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "field_83",
+                            "type": "type_2"
+                        },
+                        {
+                            "name": "field_84",
+                            "type": "long"
+                        },
+                        {
+                            "name": "field_85",
+                            "type": "string"
+                        },
+                        {
+                            "name": "field_86",
+                            "type": {
+                                "type": "record",
+                                "name": "type_18",
+                                "fields": [
+                                    {
+                                        "name": "field_87",
+                                        "type": "long"
+                                    },
+                                    {
+                                        "name": "field_88",
+                                        "type": "string"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "name": "field_89",
+                            "type": "type_7"
+                        },
+                        {
+                            "name": "field_90",
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "field_91",
+                            "type": "string"
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "name": "field_92",
+            "type": {
+                "type": "array",
+                "items": {
+                    "type": "record",
+                    "name": "type_19",
+                    "fields": [
+                        {
+                            "name": "field_93",
+                            "type": "string"
+                        },
+                        {
+                            "name": "field_94",
+                            "type": "long"
+                        },
+                        {
+                            "name": "field_95",
+                            "type": "type_4"
+                        },
+                        {
+                            "name": "field_96",
+                            "type": "type_4"
+                        },
+                        {
+                            "name": "field_97",
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "field_98",
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "field_99",
+                            "type": "string"
+                        },
+                        {
+                            "name": "field_100",
+                            "type": "type_18"
+                        },
+                        {
+                            "name": "field_101",
+                            "type": "type_7"
+                        },
+                        {
+                            "name": "field_102",
+                            "type": {
+                                "type": "record",
+                                "name": "type_20",
+                                "fields": [
+                                    {
+                                        "name": "field_103",
+                                        "type": "long"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    ]
+}]]
+
+-- gh-124: we should not reach LuaJIT's 200 local variables limit
+t {
+    schema = large,
+    compile_only = true,
+}


### PR DESCRIPTION
This reverts commit c122bd108872a0f52ac688cdc733f7365bd950cd.

The reverted commit breaks variables reusing in generated code (see
sched_variables_helper()), so it was possible to reach 200 local
variables limit when trying to compile a large schema.

Added a test case.

Fixes #124.