### PR TITLE
reload: fix avro_schema.runtime

### DIFF
--- a/test/api_tests/reload.lua
+++ b/test/api_tests/reload.lua
@@ -11,7 +11,12 @@ test:test('reload test', function(test)
 
     -- Unload it.
     package.loaded['avro_schema'] = nil
+    package.loaded['avro_schema.backend'] = nil
+    package.loaded['avro_schema.compiler'] = nil
+    package.loaded['avro_schema.fingerprint'] = nil
     package.loaded['avro_schema.il'] = nil
+    package.loaded['avro_schema.runtime'] = nil
+    package.loaded['avro_schema.utils'] = nil
 
     -- Require it again.
     local ok, err = pcall(require, 'avro_schema')


### PR DESCRIPTION
Previous patch (bbcf5fc14e3fd1962351574d3f6c30e84bcf7c92) fixed
only part of problem - avro_schema.il.

Hovewer, avro_schema.runtime is also affected. Let's fix it
and improve reload test - add all submodules to it.

Follow-up #34