### PR TITLE
Fix case when "long" type validation allows field to have a "string" type

### DIFF
--- a/avro_schema/frontend.lua
+++ b/avro_schema/frontend.lua
@@ -769,7 +769,10 @@ copy_data = function(stack, schema, data, visited)
         stack.remove_last()
         return data
     elseif schematype == 'long' then
-        local n = tonumber(data)
+        local n
+        if type(data) == 'number' or type(data) == 'cdata' then
+            n = tonumber(data)
+        end
         if not n then
             stack.push(schema, data)
             error()

--- a/test/ddt_suite/validate.lua
+++ b/test/ddt_suite/validate.lua
@@ -133,6 +133,12 @@ t {
     validate_error = 'Not a long: 9223372036854775808ULL'
 }
 
+t {
+    schema = '"long"',
+    validate = '"42"',
+    validate_error = 'Not a long: 42'
+}
+
 -- note: IEEE 754 double precision floating-point numbers encode
 --       fraction with 52 bits, hence when the value is 2^63,
 --       the delta must be at least 2^11 (2048) to make a difference.


### PR DESCRIPTION
Since 23be848 (Validate/long: final rewrite) "long" type
validation started to handle string representation of numbers.
This happens because "tonumber" function implicitly casts some
strings to numbers. That allows to pass strings (e.g. "123") instead
of "long".

This patch fixes such behaviour and introduces corresponding
test. Currently we will try to cast to number only fields that
have "number" or "cdata" type.

Closes #133