### PR TITLE
travis-ci: remove Ubuntu Disco, add Focal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,8 @@ env:
       - OS=ubuntu DIST=trusty
       - OS=ubuntu DIST=xenial
       - OS=ubuntu DIST=bionic
-      - OS=ubuntu DIST=disco
       - OS=ubuntu DIST=eoan
+      - OS=ubuntu DIST=focal
       - OS=debian DIST=jessie
       - OS=debian DIST=stretch
       - OS=debian DIST=buster


### PR DESCRIPTION
Ubuntu Disco is EOL and fails in CI on apt repositories updating with
'does not have a Release file' errors.