### PR TITLE
don't redefine global json serializer options

### DIFF
--- a/avro_schema/compiler.lua
+++ b/avro_schema/compiler.lua
@@ -19,7 +19,7 @@
 -- https://github.com/tarantool/avro-schema/wiki/Developer-Guide
 --
 
-local json = require('json')
+local json = require('json').new()
 json.cfg{encode_use_tostring = true}
 
 local front      = require('avro_schema.frontend')

--- a/avro_schema/fingerprint.lua
+++ b/avro_schema/fingerprint.lua
@@ -2,10 +2,12 @@
 -- It was necessary to implement our json encoder, because of some special
 -- rules for avro fingerptint generation and Parsing Canonical Form generation.
 
-local json = require "json"
+local json = require("json").new()
 local frontend = require "avro_schema.frontend"
 -- Tarantool specific module
 local digest = require "digest"
+
+json.cfg{encode_use_tostring = true}
 
 local avro_json
 

--- a/avro_schema/frontend.lua
+++ b/avro_schema/frontend.lua
@@ -23,7 +23,7 @@
 -- is replaced with an object itself (loops!).
 --
 
-local json = require('json')
+local json = require('json').new()
 local ffi = require('ffi')
 local utils = require('avro_schema.utils')
 local null = ffi.cast('void *', 0)
@@ -32,6 +32,9 @@ local sub = string.sub
 local insert, remove, concat = table.insert, table.remove, table.concat
 local floor = math.floor
 local next, type = next, type
+
+json.cfg{encode_use_tostring = true}
+
 -- states of type declaration
 local TYPE_STATE = {
     NEVER_USED = nil, -- not referenced and not defined

--- a/avro_schema/il.lua
+++ b/avro_schema/il.lua
@@ -1,5 +1,5 @@
 local ffi            = require('ffi')
-local json           = require('json')
+local json           = require('json').new()
 local msgpack        = require('msgpack')
 local json_encode    = json and json.encode
 local msgpack_decode = msgpack and msgpack.decode
@@ -8,6 +8,8 @@ local format, rep    = string.format, string.rep
 local insert, remove = table.insert, table.remove
 local concat         = table.concat
 local max            = math.max
+
+json.cfg{encode_use_tostring = true}
 
 local loaded, opcode = pcall(ffi_new, 'struct schema_il_Opcode')
 


### PR DESCRIPTION
It's quite dangerous because user or another module could be done
the same after `require('avro_schema')`. There is possibility
somethig could be broken. So this patch creates separate json
serializers in avro-schema sources.