### PR TITLE
ci: bump actions to v4 in reusable_testing.yml

### DIFF
--- a/.github/workflows/reusable_testing.yml
+++ b/.github/workflows/reusable_testing.yml
@@ -14,12 +14,12 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: 'Clone the avro-schema module'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: ${{ github.repository_owner }}/avro-schema
 
       - name: 'Download the tarantool build artifact'
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.artifact_name }}
 


### PR DESCRIPTION
Bump version of the `actions/checkout` and `actions/download-artifact` actions to v4 for fixing the following GitHub warning:

    Node.js 16 actions are deprecated.
    Please update the following actions to use Node.js 20