### PR TITLE
ci: bump actions to use ubuntu-24.04 image

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -10,7 +10,7 @@ jobs:
     if: |
       github.event_name == 'push' ||
       github.event.pull_request.head.repo.full_name != github.repository
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check module version
         # We need this step to run only on push with tag.
@@ -27,7 +27,7 @@ jobs:
       github.event.pull_request.head.repo.full_name != github.repository
     # Packaging for CentOS 7 does not work with other versions, see:
     # https://github.com/packpack/packpack/issues/145
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs: version-check
 
     strategy:
@@ -53,12 +53,12 @@ jobs:
 
     steps:
       - name: Clone the module
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Clone the packpack tool
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: packpack/packpack
           path: packpack

--- a/.github/workflows/push_rockspec.yml
+++ b/.github/workflows/push_rockspec.yml
@@ -14,7 +14,7 @@ jobs:
   version-check:
     # We need this job to run only on push with tag.
     if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check module version
         uses: tarantool/actions/check-module-version@master
@@ -22,7 +22,7 @@ jobs:
           module-name: "avro_schema"
 
   push-scm-rockspec:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     if: github.ref == 'refs/heads/master'
     steps:
       - uses: actions/checkout@master
@@ -33,7 +33,7 @@ jobs:
           files: ${{ env.ROCK_NAME }}-scm-1.rockspec
 
   push-tagged-rockspec:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     if: startsWith(github.ref, 'refs/tags')
     needs: version-check
     steps:

--- a/.github/workflows/reusable_testing.yml
+++ b/.github/workflows/reusable_testing.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   run_tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: 'Clone the avro-schema module'
         uses: actions/checkout@v4

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -15,22 +15,20 @@ jobs:
     if: github.event_name == 'push' ||
       github.event.pull_request.head.repo.full_name != github.repository
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     strategy:
       fail-fast: false
       matrix:
         tarantool:
-          - '1.10'
-          - '2.8'
-          - '2.10'
+          - '2.11'
 
     steps:
       - name: Clone the module
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup tarantool ${{ matrix.tarantool }}
-        uses: tarantool/setup-tarantool@v2
+        uses: tarantool/setup-tarantool@v3
         with:
           tarantool-version: ${{ matrix.tarantool }}
 


### PR DESCRIPTION
Bump actions to use newer ubuntu image for fixing the following
GitHub warning:

    The Ubuntu 20.04 Actions runner image will begin deprecation
    on 2025-02-01.

Part of #TNTP-1918